### PR TITLE
ci: replace fake julia-actions/setup-julia SHA (824fb972 → 4c0cb0fc)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         julia-version: ['1.9', '1.10', '1.11']
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - uses: julia-actions/setup-julia@824fb972babf1837cf21c49159bf8a8130f26840 # v2
+      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
         with:
           version: ${{ matrix.julia-version }}
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
-      - uses: julia-actions/setup-julia@824fb972babf1837cf21c49159bf8a8130f26840 # v2
+      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
         with:
           version: ${{ matrix.julia-version }}
 
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
-      - uses: julia-actions/setup-julia@824fb972babf1837cf21c49159bf8a8130f26840 # v2
+      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
         with:
           version: '1.10'
 


### PR DESCRIPTION
## Summary

`julia-actions/setup-julia@824fb972babf1837cf21c49159bf8a8130f26840` returns HTTP 422 "No commit found" — it is a **fake SHA pin**, never resolved by GitHub. Every CI run on this repo failed at `Unable to resolve action julia-actions/setup-julia@824fb972...`.

## Fix

Replace with the real v3 SHA `4c0cb0fce8556fdb04a90347310e5db8b1f98fb9` (verified via `gh api repos/julia-actions/setup-julia/commits/<sha>` → 200).

## Estate-wide context

One of 8 Julia repos affected. Same fix recipe across all. Caught by the 2026-05-30 estate CI/CD audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)