### PR TITLE
ci: cut Actions burn — scope push triggers + concurrency-cancel

### DIFF
--- a/.github/workflows/k9-svc-validation.yml
+++ b/.github/workflows/k9-svc-validation.yml
@@ -1,5 +1,14 @@
 name: K9-SVC Validation
-on: [push, pull_request]
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+# Estate guardrail: scope push to default branches (PR fires once, not
+# push+PR) and cancel superseded runs. Safe — read-only PR check.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions: read-all
 jobs:
   validate:


### PR DESCRIPTION
Automated by hypatia ci-health-sweep. Scopes `push` to the default branch (kills push+PR double-runs) and adds `concurrency: cancel-in-progress` to read-only PR checks. No SPDX/logic changes.