### PR TITLE
fix(ci): repoint the deleted validate-actions at the live ecosystem repos

### DIFF
--- a/.github/workflows/dogfood-gate.yml
+++ b/.github/workflows/dogfood-gate.yml
@@ -33,7 +33,7 @@ jobs:
           fi
       - name: Validate A2ML manifests
         if: steps.detect.outputs.count > 0
-        uses: hyperpolymath/a2ml-validate-action@59145c7d1039fa3059b3ecacdb50ee23d7505898 # main
+        uses: hyperpolymath/a2ml-ecosystem/validate-action@aa4b836bd969df2bc58128cb8e3d20bbc88d5e79 # main
         with:
           path: '.'
           strict: 'false'
@@ -77,7 +77,7 @@ jobs:
           fi
       - name: Validate K9 contracts
         if: steps.detect.outputs.k9_count > 0
-        uses: hyperpolymath/k9-validate-action@2d96f43c538964b097d159ed3a56ba5b5ceca227 # main
+        uses: hyperpolymath/k9-ecosystem/validate-action@89f3c2702f4f650a92aa7411502f38da06abd562 # main
         with:
           path: '.'
           strict: 'false'


### PR DESCRIPTION
`hyperpolymath/a2ml-validate-action` and `k9-validate-action` are **deleted** (verified 404). An unresolvable `uses:` ref produces **no check run at all** — not a red one — so `Validate A2ML manifests` and `Validate K9 contracts` could never report, and any ruleset requiring them was unsatisfiable. The repo looked green while the check had simply never run.

The actions **moved**: `a2ml-ecosystem/validate-action` and `k9-ecosystem/validate-action`. Repointed rather than vendored — vendoring would create one drifting copy per repo.

Measured scope: **69 repos, 135 references**. SHAs are those already proven green in `the-nash-equilibrium#83`.

**Verified:** no dead refs remain; every touched workflow still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)