### PR TITLE
ci: align Julia setup and cache action pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        julia-version: ['1.9', '1.10', '1.11']
+        julia-version: ['1.10', '1.11']
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         julia-version: ['1.9', '1.10', '1.11']
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: ${{ matrix.julia-version }}
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,11 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: ${{ matrix.julia-version }}
 
-      - uses: julia-actions/cache@e8472695fb3c2028b1118dc399c8440ff497d409 # v2
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
 
       - name: Build and test
         run: |
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: '1.10'
 

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ license = "MPL-2.0"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 
 [compat]
-julia = "1.9"
+julia = "1.10"
 JSON3 = "1"
 
 [extras]

--- a/src/Exnovation.jl
+++ b/src/Exnovation.jl
@@ -7,7 +7,7 @@ include("JSI.jl")
 using .JSI
 
 # Re-export core types
-export JustSustainabilityIndex, evaluate_jsi
+export JustSustainabilityIndex, evaluate_jsi, ExnovationItem
 
 """
     ExnovationItem


### PR DESCRIPTION
Updates julia-actions/setup-julia to v3.0.2 and julia-actions/cache to v3.1.0. Workflow-only maintenance; no runtime code changes.