### PR TITLE
fix: export ExnovationItem

### DIFF
--- a/src/Exnovation.jl
+++ b/src/Exnovation.jl
@@ -7,7 +7,7 @@ include("JSI.jl")
 using .JSI
 
 # Re-export core types
-export JustSustainabilityIndex, evaluate_jsi
+export JustSustainabilityIndex, evaluate_jsi, ExnovationItem
 
 """
     ExnovationItem


### PR DESCRIPTION
The CI test uses the documented ExnovationItem API. Export the type from the package module so it is available after using Exnovation.